### PR TITLE
add a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 torch
+torch_geometric
 numpy
 cython
 tensorboard


### PR DESCRIPTION
step 2 of the getting started, python -m AlphaZeroGUI.main fails because there's no module torch_geometric.  I added it and it seems to solve the issue.